### PR TITLE
Fix conversation reopening

### DIFF
--- a/jobs/handleGmailWebhookEvent.ts
+++ b/jobs/handleGmailWebhookEvent.ts
@@ -302,6 +302,7 @@ export const handleGmailWebhookEvent = async ({ body, headers }: any) => {
             slug: conversations.slug,
             status: conversations.status,
             assignedToAI: conversations.assignedToAI,
+            closedAt: conversations.closedAt,
           })
           .then(takeUniqueOrThrow);
       };
@@ -320,6 +321,7 @@ export const handleGmailWebhookEvent = async ({ body, headers }: any) => {
                 slug: true,
                 status: true,
                 assignedToAI: true,
+                closedAt: true,
               },
             },
           },
@@ -344,7 +346,8 @@ export const handleGmailWebhookEvent = async ({ body, headers }: any) => {
       if (
         conversation.status === "closed" &&
         (!conversation.assignedToAI || mailbox.preferences?.autoRespondEmailToChat === "draft") &&
-        !shouldIgnore
+        !shouldIgnore &&
+        (!conversation.closedAt || newEmail.createdAt > conversation.closedAt)
       ) {
         await updateConversation(conversation.id, { set: { status: "open" } });
       }


### PR DESCRIPTION
## Summary
- return `closedAt` when creating or fetching Gmail conversations
- only reopen when the email is newer than the `closedAt` time

## Testing
- `pnpm test` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ae11d7a188326b35fdacbc69aa9e7